### PR TITLE
Use telematics as default

### DIFF
--- a/pypolestar/api.py
+++ b/pypolestar/api.py
@@ -159,6 +159,9 @@ class PolestarApi:
             except Exception as exc:
                 raise ValueError("Failed to convert car battery data") from exc
 
+        if telematics := self.get_car_telematics(vin):
+            return telematics.battery
+
     def get_car_odometer(self, vin: str) -> CarOdometerData | None:
         """
         Get car odometer information for the specified VIN.
@@ -179,6 +182,9 @@ class PolestarApi:
                 return CarOdometerData.from_dict(data)
             except Exception as exc:
                 raise ValueError("Failed to convert car odometer data") from exc
+
+        if telematics := self.get_car_telematics(vin):
+            return telematics.odometer
 
     async def update_latest_data(
         self,

--- a/pypolestar/api.py
+++ b/pypolestar/api.py
@@ -184,9 +184,9 @@ class PolestarApi:
         self,
         vin: str,
         update_vehicle: bool = False,
-        update_odometer: bool = True,
-        update_battery: bool = True,
-        update_telematics: bool = False,
+        update_odometer: bool = False,
+        update_battery: bool = False,
+        update_telematics: bool = True,
     ) -> None:
         """Get the latest data from the Polestar API."""
 

--- a/pypolestar/cli.py
+++ b/pypolestar/cli.py
@@ -52,7 +52,7 @@ async def async_main():
 
     if args.dump:
         for vin in [args.vin] if args.vin else api.get_available_vins():
-            await api.update_latest_data(vin, update_telematics=True, update_battery=True, update_odometer=True)
+            await api.update_latest_data(vin)
             dump_api_data(api, vin)
 
 


### PR DESCRIPTION
Polestar has removed (?) the `GetOdometerData` call, use `CarTelematics` by default for updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Adjusted the default data update behavior so that telematics information is refreshed automatically, while odometer and battery details are now updated only when explicitly requested.
  - Streamlined the command-line tool to trigger updates using just the vehicle identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->