### PR TITLE
Report "PolestarN" as "Polestar N" for consistency

### DIFF
--- a/pypolestar/models.py
+++ b/pypolestar/models.py
@@ -146,13 +146,18 @@ class CarInformationData(CarBaseInformation):
         if not isinstance(data, dict):
             raise TypeError
 
+        # "Polestar 4" is reported as "Polestar4"
+        model_name = get_field_name_str("content/model/name", data)
+        if match := re.match(r"^([A-Za-z]+)(\d+)$", model_name):
+            model_name = " ".join([match.group(1), match.group(2)])
+
         return cls(
             vin=get_field_name_str("vin", data),
             internal_vehicle_identifier=get_field_name_str("internalVehicleIdentifier", data),
             registration_no=get_field_name_str("registrationNo", data),
             registration_date=get_field_name_date("registrationDate", data),
             factory_complete_date=get_field_name_date("factoryCompleteDate", data),
-            model_name=get_field_name_str("content/model/name", data),
+            model_name=model_name,
             image_url=get_field_name_str("content/images/studio/url", data),
             battery=get_field_name_str("content/specification/battery", data),
             torque=get_field_name_str("content/specification/torque", data),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,7 +101,7 @@ def test_car_information_data_polestar4(polestar4_test_data):
     assert data.registration_no == "MLB007"
     assert data.registration_date is None
     assert data.factory_complete_date == date(year=2024, month=7, day=11)
-    assert data.model_name == "Polestar4"
+    assert data.model_name == "Polestar 4"
     assert (
         data.image_url
         == "https://car-images.polestar.com/carvis/pub/prod/814/2025/summary-transparent/PB/37000/P04300/19/221014/_/220004/_/1/221010/default.png"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vehicle model naming so that names now include appropriate spacing (e.g., "Polestar4" is displayed as "Polestar 4").
  - Enhanced battery information formatting by adding proper spacing for clearer, more readable details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->