### PR TITLE
Log out on token failure

### DIFF
--- a/pypolestar/auth.py
+++ b/pypolestar/auth.py
@@ -133,6 +133,7 @@ class PolestarAuth:
                 self.logger.debug("Initial token acquired")
                 return
             except Exception as exc:
+                await self.async_logout()
                 raise PolestarAuthException("Unable to acquire initial token") from exc
 
     def _parse_token_response(self, response: httpx.Response) -> None:


### PR DESCRIPTION
If we fail to acquire a token, logout and start fresh (without any cookies)