### PR TITLE
Remove image url for now

### DIFF
--- a/pypolestar/graphql.py
+++ b/pypolestar/graphql.py
@@ -64,9 +64,6 @@ QUERY_GET_CONSUMER_CARS_V2 = gql(
             factoryCompleteDate
             content {
                 model { name }
-                images {
-                    studio { url }
-                }
                 specification {
                     battery
                     torque
@@ -128,11 +125,6 @@ QUERY_GET_CONSUMER_CARS_V2_VERBOSE = gql(
                 pilotPackage { code name description excluded }
                 motor { name description excluded }
                 model { name code }
-                images {
-                    studio { url angles resolutions }
-                    location { url angles resolutions }
-                    interior { url angles resolutions }
-                }
                 specification {
                     battery
                     bodyType

--- a/pypolestar/models.py
+++ b/pypolestar/models.py
@@ -167,7 +167,7 @@ class CarInformationData(CarBaseInformation):
             registration_date=get_field_name_date("registrationDate", data),
             factory_complete_date=get_field_name_date("factoryCompleteDate", data),
             model_name=model_name,
-            image_url=get_field_name_str("content/images/studio/url", data),
+            image_url=None,
             battery=get_field_name_str("content/specification/battery", data),
             torque=get_field_name_str("content/specification/torque", data),
             software_version=get_field_name_str("software/version", data),

--- a/tests/data/polestar2.json
+++ b/tests/data/polestar2.json
@@ -9,11 +9,6 @@
       "model": {
         "name": "Polestar 2"
       },
-      "images": {
-        "studio": {
-          "url": "https://cas.polestar.com/image/dynamic/MY24_2335/534/summary-transparent-v1/FE/1/19/72900/RFA000/R184/LR02/_/BD02/EV05/JB0A/2G03/ET01/default.png?market=pt"
-        }
-      },
       "specification": {
         "battery": "82 kWh",
         "torque": "490 Nm / 361 lb-ft"

--- a/tests/data/polestar3.json
+++ b/tests/data/polestar3.json
@@ -9,11 +9,6 @@
       "model": {
         "name": "Polestar 3"
       },
-      "images": {
-        "studio": {
-          "url": "https://cas.polestar.com/image/dynamic/MY24_2207/359/summary-transparent-v2/EA/1/72300/R80000/R102/LR02/EV02/K503/JB07/SW01/_/ET01/default.png?market=se"
-        }
-      },
       "specification": {
         "battery": "400V lithium-ion battery, 111 kWh capacity, 17 modules",
         "torque": "840 Nm / 620 lbf-ft"
@@ -25,9 +20,7 @@
     }
   },
   "carTelematicsV2": {
-    "health": [
-      null
-    ],
+    "health": [null],
     "battery": [
       {
         "vin": "YSMYKEAE7RB000000",

--- a/tests/data/polestar4.json
+++ b/tests/data/polestar4.json
@@ -1,67 +1,62 @@
 {
-	"getConsumerCarsV2": {
-		"vin": "XXXXXXXXXXX000000",
-		"internalVehicleIdentifier": "cf4bfecc-cb00-49f3-af84-4a5b21b02da6",
-		"registrationNo": "MLB007",
-		"registrationDate": null,
-		"factoryCompleteDate": "2024-07-11",
-		"content": {
-			"model": {
-				"name": "Polestar4"
-			},
-			"images": {
-				"studio": {
-					"url": "https://car-images.polestar.com/carvis/pub/prod/814/2025/summary-transparent/PB/37000/P04300/19/221014/_/220004/_/1/221010/default.png"
-				}
-			},
-			"specification": {
-				"battery": "400Vlithium-ionbattery,100kWhcapacity,cell-to-pack,110cells",
-				"torque": "343Nm/253lbf-ft"
-			}
-		},
-		"software": {
-			"version": null,
-			"versionTimestamp": null
-		}
-	},
-	"carTelematics": {
-		"health": {
-			"brakeFluidLevelWarning": "BRAKE_FLUID_LEVEL_WARNING_NO_WARNING",
-			"daysToService": 601,
-			"distanceToServiceKm": 26515,
-			"engineCoolantLevelWarning": null,
-			"eventUpdatedTimestamp": {
-				"iso": "2025-02-15T08:01:37.000Z",
-				"unix": "1739606497"
-			},
-			"oilLevelWarning": null,
-			"serviceWarning": "SERVICE_WARNING_NO_WARNING"
-		},
-		"battery": {
-			"averageEnergyConsumptionKwhPer100Km": null,
-			"batteryChargeLevelPercentage": 42,
-			"chargerConnectionStatus": "CHARGER_CONNECTION_STATUS_DISCONNECTED",
-			"chargingCurrentAmps": null,
-			"chargingPowerWatts": null,
-			"chargingStatus": "CHARGING_STATUS_IDLE",
-			"estimatedChargingTimeMinutesToTargetDistance": null,
-			"estimatedChargingTimeToFullMinutes": 74,
-			"estimatedDistanceToEmptyKm": 261,
-			"estimatedDistanceToEmptyMiles": 162,
-			"eventUpdatedTimestamp": {
-				"iso": "2025-02-15T08:01:37.000Z",
-				"unix": "1739606497"
-			}
-		},
-		"odometer": {
-			"averageSpeedKmPerHour": null,
-			"eventUpdatedTimestamp": {
-				"iso": "2025-02-15T08:01:37.000Z",
-				"unix": "1739606497"
-			},
-			"odometerMeters": 3525000,
-			"tripMeterAutomaticKm": 9,
-			"tripMeterManualKm": 3459
-		}
-	}
+  "getConsumerCarsV2": {
+    "vin": "XXXXXXXXXXX000000",
+    "internalVehicleIdentifier": "cf4bfecc-cb00-49f3-af84-4a5b21b02da6",
+    "registrationNo": "MLB007",
+    "registrationDate": null,
+    "factoryCompleteDate": "2024-07-11",
+    "content": {
+      "model": {
+        "name": "Polestar4"
+      },
+      "specification": {
+        "battery": "400Vlithium-ionbattery,100kWhcapacity,cell-to-pack,110cells",
+        "torque": "343Nm/253lbf-ft"
+      }
+    },
+    "software": {
+      "version": null,
+      "versionTimestamp": null
+    }
+  },
+  "carTelematics": {
+    "health": {
+      "brakeFluidLevelWarning": "BRAKE_FLUID_LEVEL_WARNING_NO_WARNING",
+      "daysToService": 601,
+      "distanceToServiceKm": 26515,
+      "engineCoolantLevelWarning": null,
+      "eventUpdatedTimestamp": {
+        "iso": "2025-02-15T08:01:37.000Z",
+        "unix": "1739606497"
+      },
+      "oilLevelWarning": null,
+      "serviceWarning": "SERVICE_WARNING_NO_WARNING"
+    },
+    "battery": {
+      "averageEnergyConsumptionKwhPer100Km": null,
+      "batteryChargeLevelPercentage": 42,
+      "chargerConnectionStatus": "CHARGER_CONNECTION_STATUS_DISCONNECTED",
+      "chargingCurrentAmps": null,
+      "chargingPowerWatts": null,
+      "chargingStatus": "CHARGING_STATUS_IDLE",
+      "estimatedChargingTimeMinutesToTargetDistance": null,
+      "estimatedChargingTimeToFullMinutes": 74,
+      "estimatedDistanceToEmptyKm": 261,
+      "estimatedDistanceToEmptyMiles": 162,
+      "eventUpdatedTimestamp": {
+        "iso": "2025-02-15T08:01:37.000Z",
+        "unix": "1739606497"
+      }
+    },
+    "odometer": {
+      "averageSpeedKmPerHour": null,
+      "eventUpdatedTimestamp": {
+        "iso": "2025-02-15T08:01:37.000Z",
+        "unix": "1739606497"
+      },
+      "odometerMeters": 3525000,
+      "tripMeterAutomaticKm": 9,
+      "tripMeterManualKm": 3459
+    }
+  }
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -58,10 +58,7 @@ def test_car_information_data_polestar2(polestar2_test_data):
     assert data.registration_date == date(year=2023, month=8, day=1)
     assert data.factory_complete_date == date(year=2023, month=5, day=20)
     assert data.model_name == "Polestar 2"
-    assert (
-        data.image_url
-        == "https://cas.polestar.com/image/dynamic/MY24_2335/534/summary-transparent-v1/FE/1/19/72900/RFA000/R184/LR02/_/BD02/EV05/JB0A/2G03/ET01/default.png?market=pt"
-    )
+    assert data.image_url is None
     assert data.battery == "82 kWh"
     assert data.torque == "490 Nm / 361 lb-ft"
     assert data.software_version == "P03.01"
@@ -80,10 +77,7 @@ def test_car_information_data_polestar3(polestar3_test_data):
     assert data.registration_date is None
     assert data.factory_complete_date == date(year=2024, month=4, day=16)
     assert data.model_name == "Polestar 3"
-    assert (
-        data.image_url
-        == "https://cas.polestar.com/image/dynamic/MY24_2207/359/summary-transparent-v2/EA/1/72300/R80000/R102/LR02/EV02/K503/JB07/SW01/_/ET01/default.png?market=se"
-    )
+    assert data.image_url is None
     assert data.battery == "400V lithium-ion battery, 111 kWh capacity, 17 modules"
     assert data.torque == "840 Nm / 620 lbf-ft"
     assert data.software_version is None
@@ -102,10 +96,7 @@ def test_car_information_data_polestar4(polestar4_test_data):
     assert data.registration_date is None
     assert data.factory_complete_date == date(year=2024, month=7, day=11)
     assert data.model_name == "Polestar 4"
-    assert (
-        data.image_url
-        == "https://car-images.polestar.com/carvis/pub/prod/814/2025/summary-transparent/PB/37000/P04300/19/221014/_/220004/_/1/221010/default.png"
-    )
+    assert data.image_url is None
     assert data.battery == "400Vlithium-ionbattery,100kWhcapacity,cell-to-pack,110cells"
     assert data.torque == "343Nm/253lbf-ft"
     assert data.software_version is None


### PR DESCRIPTION
Polestar has moved the car image URLs, remove them from now (will be addressed separately)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Image-related fields and image URLs have been removed from API responses and internal vehicle records; image data is no longer populated.
* **Tests**
  * Sample data and unit tests updated to expect no image URLs for vehicles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->