### PR TITLE
Remove charging status

### DIFF
--- a/pypolestar/graphql.py
+++ b/pypolestar/graphql.py
@@ -86,7 +86,6 @@ QUERY_TELEMATICS_V2 = gql(
             battery {
                 vin
                 batteryChargeLevelPercentage
-                chargingStatus
                 estimatedChargingTimeToFullMinutes
                 estimatedDistanceToEmptyKm
                 timestamp { seconds nanos }

--- a/pypolestar/models.py
+++ b/pypolestar/models.py
@@ -197,7 +197,7 @@ class CarBatteryData(CarBaseInformation):
     charger_connection_status: ChargingConnectionStatus | None
     charging_current_amps: int | None
     charging_power_watts: int | None
-    charging_status: ChargingStatus
+    charging_status: ChargingStatus | None
     estimated_charging_time_minutes_to_target_distance: int | None
     estimated_charging_time_to_full_minutes: int | None
     estimated_distance_to_empty_km: int | None
@@ -247,18 +247,13 @@ class CarBatteryData(CarBaseInformation):
         if not isinstance(data, dict):
             raise TypeError
 
-        charging_status = ChargingStatus.get(
-            data["chargingStatus"],
-            ChargingStatus.CHARGING_STATUS_UNSPECIFIED,
-        )
-
         return cls(
             average_energy_consumption_kwh_per_100km=None,
             battery_charge_level_percentage=get_field_name_int("batteryChargeLevelPercentage", data),
             charger_connection_status=None,
             charging_current_amps=None,
             charging_power_watts=None,
-            charging_status=charging_status,
+            charging_status=None,
             estimated_charging_time_minutes_to_target_distance=None,
             estimated_charging_time_to_full_minutes=get_field_name_int("estimatedChargingTimeToFullMinutes", data),
             estimated_distance_to_empty_km=get_field_name_int("estimatedDistanceToEmptyKm", data),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -198,7 +198,7 @@ def test_telematics_information_data_polestar3(polestar3_test_data):
     assert data.battery.charger_connection_status is None
     assert data.battery.charging_current_amps is None
     assert data.battery.charging_power_watts is None
-    assert data.battery.charging_status == ChargingStatus.CHARGING_STATUS_IDLE
+    assert data.battery.charging_status is None
     assert data.battery.estimated_charging_time_minutes_to_target_distance is None
     assert data.battery.estimated_charging_time_to_full_minutes == 0
     assert data.battery.estimated_distance_to_empty_km == 390


### PR DESCRIPTION
Polestar has removed charging status from the GraphQL API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Charging status information is no longer retrieved from the API and will return as unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pypolestar/pypolestar/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->