### PR TITLE
Only compute estimated_fully_charged while charging

### DIFF
--- a/pypolestar/models.py
+++ b/pypolestar/models.py
@@ -233,7 +233,8 @@ class CarBatteryData(CarBaseInformation):
         - Battery is already fully charged
         """
         if (
-            self.estimated_charging_time_to_full_minutes
+            self.charging_status == ChargingStatus.CHARGING_STATUS_CHARGING
+            and self.estimated_charging_time_to_full_minutes
             and self.estimated_charging_time_to_full_minutes > 0
             and self.battery_charge_level_percentage is not None
             and self.battery_charge_level_percentage < 100

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -136,10 +136,10 @@ def test_car_battery_data_rate():
         _received_timestamp=datetime.now(tz=timezone.utc),
         average_energy_consumption_kwh_per_100km=None,
         battery_charge_level_percentage=55,
-        charger_connection_status=ChargingConnectionStatus.CHARGER_CONNECTION_STATUS_DISCONNECTED,
-        charging_current_amps=0,
-        charging_power_watts=0,
-        charging_status=ChargingStatus.CHARGING_STATUS_IDLE,
+        charger_connection_status=ChargingConnectionStatus.CHARGER_CONNECTION_STATUS_CONNECTED,
+        charging_current_amps=15,
+        charging_power_watts=11000,
+        charging_status=ChargingStatus.CHARGING_STATUS_CHARGING,
         estimated_charging_time_minutes_to_target_distance=None,
         estimated_charging_time_to_full_minutes=60,
         estimated_distance_to_empty_km=300,
@@ -151,6 +151,27 @@ def test_car_battery_data_rate():
     fully_charged_at = datetime.now(tz=timezone.utc) + timedelta(minutes=59)
     assert data.estimated_fully_charged is not None
     assert data.estimated_fully_charged > fully_charged_at
+
+
+def test_estimated_fully_charged_requires_charging():
+    def battery(charging_status):
+        return CarBatteryData(
+            _received_timestamp=datetime.now(tz=timezone.utc),
+            average_energy_consumption_kwh_per_100km=None,
+            battery_charge_level_percentage=55,
+            charger_connection_status=ChargingConnectionStatus.CHARGER_CONNECTION_STATUS_CONNECTED,
+            charging_current_amps=15,
+            charging_power_watts=11000,
+            charging_status=charging_status,
+            estimated_charging_time_minutes_to_target_distance=None,
+            estimated_charging_time_to_full_minutes=60,
+            estimated_distance_to_empty_km=300,
+            event_updated_timestamp=None,
+        )
+
+    assert battery(ChargingStatus.CHARGING_STATUS_CHARGING).estimated_fully_charged is not None
+    assert battery(ChargingStatus.CHARGING_STATUS_IDLE).estimated_fully_charged is None
+    assert battery(None).estimated_fully_charged is None
 
 
 def test_car_battery_data_invalid():


### PR DESCRIPTION
On my polestar 4, this estimate is returned even when the car is not charging or not plugged in.   This results in a new entry in home assistant every minute for `estimated_fully_charged_time`, which fills up the history.

Tested on a Polestar 4 (pypolestar 1.12.5): during charge status idle and scheduled now return `None`.

Fixes https://github.com/pypolestar/polestar_api/issues/433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved estimated full-charge times so they’re computed only while the vehicle is actively charging.
  * Prevented full-charge completion estimates from being shown when the vehicle is idle or not charging.
* **Tests**
  * Updated battery charging test data to reflect an actively charging state.
  * Added coverage to confirm the estimate is present only for the actively charging status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->