### PR TITLE
Stop retrying gRPC calls the backend permanently refuses

### DIFF
--- a/pypolestar/api.py
+++ b/pypolestar/api.py
@@ -211,6 +211,20 @@ class PolestarApi:
         self._ensure_data_for_vin(vin)
         return self.data_by_vin[vin].get(GRPC_TARGET_SOC_DATA)
 
+    def is_grpc_battery_supported(self, vin: str) -> bool:
+        """Whether the vehicle serves battery data via gRPC (false once the backend has refused it)."""
+        return self.grpc_client.is_battery_supported(vin) if self.grpc_client else False
+
+    def is_grpc_target_soc_supported(self, vin: str) -> bool:
+        """Whether the vehicle serves target SOC via gRPC.
+
+        Not every vehicle is provisioned in Polestar's PCCS platform -- notably the
+        Polestar 2 -- and those return PERMISSION_DENIED. This turns false after the
+        first such refusal, so consumers can drop the entity instead of showing it
+        permanently unknown.
+        """
+        return self.grpc_client.is_target_soc_supported(vin) if self.grpc_client else False
+
     async def update_latest_data(
         self,
         vin: str,

--- a/pypolestar/grpc_client.py
+++ b/pypolestar/grpc_client.py
@@ -41,6 +41,22 @@ GRPC_PCCS_HOST = "api.pccs-prod.plstr.io"
 GRPC_PORT = 443
 GRPC_TIMEOUT = 30
 
+# gRPC status codes that mean "this vehicle will never serve this data".
+#
+# Not all vehicles are provisioned in every backend: the Polestar 2 is a Volvo
+# CMA-platform car and is not registered in Polestar's own PCCS/chronos
+# platform, so TargetSocService returns PERMISSION_DENIED for it even though
+# the access token is perfectly valid (an unauthenticated call is rejected
+# earlier, at the gateway, with UNAUTHENTICATED). Retrying such a call on every
+# poll only produces log noise, so we remember the VIN and stop asking.
+UNSUPPORTED_STATUS_CODES = frozenset(
+    {
+        grpc.StatusCode.PERMISSION_DENIED,
+        grpc.StatusCode.UNIMPLEMENTED,
+        grpc.StatusCode.NOT_FOUND,
+    }
+)
+
 
 def _connection_status(value: int) -> ChargingConnectionStatus:
     name = polestar_battery_pb2.ChargerConnectionStatus.Name(value)
@@ -71,11 +87,17 @@ class PolestarGrpcClient:
         self.client_session = client_session
         self.c3_channel: grpc.aio.Channel | None = None
         self.pccs_channel: grpc.aio.Channel | None = None
+        self.unsupported_battery: set[str] = set()
+        self.unsupported_target_soc: set[str] = set()
         self.logger = _LOGGER.getChild(unique_id) if unique_id else _LOGGER
 
     async def connect(self) -> None:
         """Connect to both gRPC servers."""
         creds = grpc.ssl_channel_credentials()
+
+        # Re-evaluate per-vehicle support on every (re)connect
+        self.unsupported_battery.clear()
+        self.unsupported_target_soc.clear()
 
         # Discover C3 gRPC host dynamically
         c3_host, c3_port = await self._discover_c3_host()
@@ -116,10 +138,33 @@ class PolestarGrpcClient:
             ("vin", vin),
         ]
 
+    def _mark_unsupported(self, unsupported: set[str], vin: str, what: str, exc: grpc.aio.AioRpcError) -> bool:
+        """Remember that a vehicle does not provide this data, if the error says so permanently."""
+        if exc.code() not in UNSUPPORTED_STATUS_CODES:
+            return False
+        unsupported.add(vin)
+        self.logger.info(
+            "gRPC %s not available for this vehicle (%s), not retrying",
+            what,
+            exc.code().name,
+        )
+        return True
+
+    def is_battery_supported(self, vin: str) -> bool:
+        """Whether the C3 battery service is known to serve data for this vehicle."""
+        return vin not in self.unsupported_battery
+
+    def is_target_soc_supported(self, vin: str) -> bool:
+        """Whether the PCCS target SOC service is known to serve data for this vehicle."""
+        return vin not in self.unsupported_target_soc
+
     async def get_battery(self, vin: str, access_token: str) -> GrpcBatteryData | None:
         """Get battery status including charger connection status via gRPC (C3/Volvo endpoint)."""
         if not self.c3_channel:
             raise RuntimeError("gRPC C3 channel not connected")
+
+        if vin in self.unsupported_battery:
+            return None
 
         request = polestar_battery_service_pb2.GetBatteryRequest(
             id=str(uuid.uuid4()),
@@ -143,6 +188,8 @@ class PolestarGrpcClient:
             return _parse_battery(response.battery)
 
         except grpc.aio.AioRpcError as exc:
+            if self._mark_unsupported(self.unsupported_battery, vin, "battery data", exc):
+                return None
             self.logger.error("gRPC GetLatestBattery failed: %s (code=%s)", exc.details(), exc.code())
             raise
 
@@ -150,6 +197,9 @@ class PolestarGrpcClient:
         """Get target SOC (charge limit) via gRPC (PCCS/Polestar endpoint)."""
         if not self.pccs_channel:
             raise RuntimeError("gRPC PCCS channel not connected")
+
+        if vin in self.unsupported_target_soc:
+            return None
 
         chronos_req = polestar_chronos_request_pb2.ChronosRequest(
             id=str(uuid.uuid4()),
@@ -180,6 +230,8 @@ class PolestarGrpcClient:
             return _parse_target_soc(response)
 
         except grpc.aio.AioRpcError as exc:
+            if self._mark_unsupported(self.unsupported_target_soc, vin, "target SOC", exc):
+                return None
             self.logger.error("gRPC GetTargetSoc failed: %s (code=%s)", exc.details(), exc.code())
             raise
 

--- a/pypolestar/grpc_client.py
+++ b/pypolestar/grpc_client.py
@@ -95,10 +95,6 @@ class PolestarGrpcClient:
         """Connect to both gRPC servers."""
         creds = grpc.ssl_channel_credentials()
 
-        # Re-evaluate per-vehicle support on every (re)connect
-        self.unsupported_battery.clear()
-        self.unsupported_target_soc.clear()
-
         # Discover C3 gRPC host dynamically
         c3_host, c3_port = await self._discover_c3_host()
         c3_target = f"{c3_host}:{c3_port}"
@@ -108,6 +104,12 @@ class PolestarGrpcClient:
         pccs_target = f"{GRPC_PCCS_HOST}:{GRPC_PORT}"
         self.pccs_channel = grpc.aio.secure_channel(pccs_target, creds)
         self.logger.debug("gRPC PCCS channel created for %s", pccs_target)
+
+        # Only now that fresh channels are in place is it worth re-evaluating
+        # per-vehicle support; a failed reconnect keeps the old channels, and
+        # with them what we already learned about these vehicles.
+        self.unsupported_battery.clear()
+        self.unsupported_target_soc.clear()
 
     async def _discover_c3_host(self) -> tuple[str, int]:
         """Discover the C3 gRPC host via the cnepmob discovery endpoint."""

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -4,6 +4,7 @@ import asyncio
 
 import grpc
 import grpc.aio
+import httpx
 import pytest
 
 from pypolestar.grpc_client import PolestarGrpcClient
@@ -11,13 +12,20 @@ from pypolestar.grpc_client import PolestarGrpcClient
 VIN = "YSMYKEAE7RB000000"
 TOKEN = "token"
 
+# Status codes the client must read as "this vehicle will never serve this data"
+PERMANENT_STATUS_CODES = [
+    grpc.StatusCode.PERMISSION_DENIED,
+    grpc.StatusCode.UNIMPLEMENTED,
+    grpc.StatusCode.NOT_FOUND,
+]
+
 
 def _rpc_error(code: grpc.StatusCode) -> grpc.aio.AioRpcError:
     return grpc.aio.AioRpcError(
         code=code,
         initial_metadata=grpc.aio.Metadata(),
         trailing_metadata=grpc.aio.Metadata(),
-        details='Status(StatusCode="PermissionDenied", Detail="")',
+        details=f'Status(StatusCode="{code.name}", Detail="")',
     )
 
 
@@ -46,9 +54,10 @@ def _client(**channels) -> PolestarGrpcClient:
     return client
 
 
-def test_target_soc_permission_denied_is_not_retried():
+@pytest.mark.parametrize("code", PERMANENT_STATUS_CODES)
+def test_target_soc_permanent_error_is_not_retried(code):
     """A Polestar 2 is not provisioned in PCCS: refuse once, then stop asking."""
-    channel = FailingChannel(_rpc_error(grpc.StatusCode.PERMISSION_DENIED))
+    channel = FailingChannel(_rpc_error(code))
     client = _client(pccs_channel=channel)
 
     assert asyncio.run(client.get_target_soc(VIN, TOKEN)) is None
@@ -71,8 +80,9 @@ def test_target_soc_transient_error_is_raised_and_retried():
     assert channel.calls == 2
 
 
-def test_battery_permission_denied_is_not_retried():
-    channel = FailingChannel(_rpc_error(grpc.StatusCode.PERMISSION_DENIED))
+@pytest.mark.parametrize("code", PERMANENT_STATUS_CODES)
+def test_battery_permanent_error_is_not_retried(code):
+    channel = FailingChannel(_rpc_error(code))
     client = _client(c3_channel=channel)
 
     assert asyncio.run(client.get_battery(VIN, TOKEN)) is None
@@ -91,3 +101,25 @@ def test_battery_transient_error_is_raised():
         asyncio.run(client.get_battery(VIN, TOKEN))
 
     assert client.is_battery_supported(VIN) is True
+
+
+def test_failed_reconnect_keeps_unsupported_vehicles():
+    """The old channels survive a failed reconnect, so what we learned must too."""
+
+    class FailingSession:
+        async def get(self, *args, **kwargs):
+            raise httpx.ConnectError("discovery unreachable")
+
+    channel = FailingChannel(_rpc_error(grpc.StatusCode.PERMISSION_DENIED))
+    client = PolestarGrpcClient(client_session=FailingSession())  # type: ignore[arg-type]
+    client.pccs_channel = channel
+
+    assert asyncio.run(client.get_target_soc(VIN, TOKEN)) is None
+    assert client.is_target_soc_supported(VIN) is False
+
+    with pytest.raises(httpx.ConnectError):
+        asyncio.run(client.connect())
+
+    assert client.is_target_soc_supported(VIN) is False
+    assert asyncio.run(client.get_target_soc(VIN, TOKEN)) is None
+    assert channel.calls == 1, "a failed reconnect must not resurrect refused calls"

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -1,0 +1,93 @@
+"""Tests for gRPC client error handling."""
+
+import asyncio
+
+import grpc
+import grpc.aio
+import pytest
+
+from pypolestar.grpc_client import PolestarGrpcClient
+
+VIN = "YSMYKEAE7RB000000"
+TOKEN = "token"
+
+
+def _rpc_error(code: grpc.StatusCode) -> grpc.aio.AioRpcError:
+    return grpc.aio.AioRpcError(
+        code=code,
+        initial_metadata=grpc.aio.Metadata(),
+        trailing_metadata=grpc.aio.Metadata(),
+        details='Status(StatusCode="PermissionDenied", Detail="")',
+    )
+
+
+class FailingChannel:
+    """Channel stub where every call raises, counting the attempts."""
+
+    def __init__(self, error: grpc.aio.AioRpcError):
+        self.error = error
+        self.calls = 0
+
+    def _fail(self, *args, **kwargs):
+        self.calls += 1
+        raise self.error
+
+    def unary_unary(self, *args, **kwargs):
+        return self._fail
+
+    def unary_stream(self, *args, **kwargs):
+        return self._fail
+
+
+def _client(**channels) -> PolestarGrpcClient:
+    client = PolestarGrpcClient(client_session=None)  # type: ignore[arg-type]
+    for name, channel in channels.items():
+        setattr(client, name, channel)
+    return client
+
+
+def test_target_soc_permission_denied_is_not_retried():
+    """A Polestar 2 is not provisioned in PCCS: refuse once, then stop asking."""
+    channel = FailingChannel(_rpc_error(grpc.StatusCode.PERMISSION_DENIED))
+    client = _client(pccs_channel=channel)
+
+    assert asyncio.run(client.get_target_soc(VIN, TOKEN)) is None
+    assert client.is_target_soc_supported(VIN) is False
+    assert channel.calls == 1
+
+    assert asyncio.run(client.get_target_soc(VIN, TOKEN)) is None
+    assert channel.calls == 1, "unsupported vehicle should not hit the network again"
+
+
+def test_target_soc_transient_error_is_raised_and_retried():
+    channel = FailingChannel(_rpc_error(grpc.StatusCode.UNAVAILABLE))
+    client = _client(pccs_channel=channel)
+
+    for _ in range(2):
+        with pytest.raises(grpc.aio.AioRpcError):
+            asyncio.run(client.get_target_soc(VIN, TOKEN))
+
+    assert client.is_target_soc_supported(VIN) is True
+    assert channel.calls == 2
+
+
+def test_battery_permission_denied_is_not_retried():
+    channel = FailingChannel(_rpc_error(grpc.StatusCode.PERMISSION_DENIED))
+    client = _client(c3_channel=channel)
+
+    assert asyncio.run(client.get_battery(VIN, TOKEN)) is None
+    assert client.is_battery_supported(VIN) is False
+    assert channel.calls == 1
+
+    assert asyncio.run(client.get_battery(VIN, TOKEN)) is None
+    assert channel.calls == 1
+
+
+def test_battery_transient_error_is_raised():
+    channel = FailingChannel(_rpc_error(grpc.StatusCode.INTERNAL))
+    client = _client(c3_channel=channel)
+
+    with pytest.raises(grpc.aio.AioRpcError):
+        asyncio.run(client.get_battery(VIN, TOKEN))
+
+    assert client.is_battery_supported(VIN) is True


### PR DESCRIPTION
Fixes the repeating `GetTargetSoc failed: PermissionDenied` errors reported in pypolestar/polestar_api#440.

## Diagnosis

Polestar 2 vehicles are not provisioned in Polestar's own PCCS/chronos platform, so `TargetSocService/GetTargetSoc` on `api.pccs-prod.plstr.io` returns `PERMISSION_DENIED` for them, while the C3 (Volvo) `BatteryService` works fine on the same token — visible in the dump attached to that issue.

The access token is not the problem: PCCS rejects an unauthenticated call earlier, at the gateway, with HTTP 401 / `UNAUTHENTICATED`. The reporters instead get `PERMISSION_DENIED` with a .NET-style body (`Status(StatusCode="PermissionDenied", Detail="")`), i.e. the token authenticated and the application then refused that VIN. Region is ruled out too — reports span AU (landing on a `kr.prod` C3 host) and EU, model years 2022 and 2025, all Polestar 2, while a Polestar 3 works.

This fits the platform split: P2 is Volvo CMA, P3/P4 are on Polestar's PCCS stack. There is no target SOC available for the P2 through either backend — GraphQL `carTelematicsV2` never exposed a charge limit for any model.

## Change

Since it is a per-vehicle entitlement rather than something a retry can fix, but the previous code re-issued the RPC on every poll and logged it at `ERROR` (client) plus `WARNING` (api) — which surfaces as repeating errors in Home Assistant for every P2 owner:

- Treat `PERMISSION_DENIED`, `UNIMPLEMENTED` and `NOT_FOUND` as "this vehicle will never serve this data": log once at `INFO`, remember the VIN, and return `None` without touching the network again. Applied to both `get_target_soc` and `get_battery`.
- Other status codes keep logging at `ERROR` and raising, so genuine outages stay visible and retried.
- The cache is cleared in `connect()`, so an integration reload re-evaluates.
- New `is_grpc_target_soc_supported(vin)` / `is_grpc_battery_supported(vin)` on `PolestarApi`, so consumers can distinguish "not fetched yet" from "never available" and drop the entity instead of showing it permanently unknown.

Detection is dynamic rather than gated on `modelName == "Polestar 2"`, so it also covers other unprovisioned vehicles; it costs exactly one refused RPC per session.

A follow-up in `polestar_api` can use `is_grpc_target_soc_supported()` to skip creating the target SOC entity at setup.

## Tests

`tests/test_grpc_client.py` covers the permanent and transient paths for both RPCs, including that an unsupported vehicle is not re-queried. Written with `asyncio.run()` to avoid adding a `pytest-asyncio` dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support checks for battery data and target state-of-charge features.
  * Applications can now determine whether these features are available for a vehicle.

* **Bug Fixes**
  * Unsupported features are recognized and no longer repeatedly requested.
  * Temporary service failures remain retryable, while permanent access or availability errors are handled gracefully.
  * Support status is refreshed after reconnecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->